### PR TITLE
added utility scripts, behavior scripts, and cleaned up some initial …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Godot 4+ specific ignores
+.godot/
+
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json
+
+# Mac why
+**/.DS_Store
+
+builds/

--- a/godot/components/entities/Entity.gd
+++ b/godot/components/entities/Entity.gd
@@ -1,0 +1,40 @@
+extends CharacterBody2D
+class_name Entity
+
+enum State {
+	IDLE,
+	AGGRO
+}
+
+const MAX_FALL_SPEED = 800.0
+var gravity = ProjectSettings.get_setting("physics/2d/default_gravity")
+
+@export var idle_behavior: EntityBehavior
+@export var aggro_behavior: EntityBehavior
+@export var detection_area: Area2D
+@export var has_gravity = true
+
+var _current_state = State.IDLE
+var _is_facing_right = true
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	if detection_area != null:
+		detection_area.area_entered.connect(_on_player_detected)
+		detection_area.area_exited.connect(_on_player_undetected)
+
+func _physics_process(delta):
+	if aggro_behavior != null && _current_state == State.AGGRO:
+		aggro_behavior.apply_behavior(self, delta)
+	elif idle_behavior != null:
+		idle_behavior.apply_behavior(self, delta)
+		
+	move_and_slide()
+
+func _on_player_detected(player):
+	if player != null && player is Player:
+		_current_state = State.AGGRO
+
+func _on_player_undetected(player):
+	if player != null && player is Player:
+		_current_state = State.IDLE

--- a/godot/components/entities/behaviors/scripts/EntityBehavior.gd
+++ b/godot/components/entities/behaviors/scripts/EntityBehavior.gd
@@ -1,0 +1,6 @@
+class_name EntityBehavior
+extends Node2D
+
+func apply_behavior(character: Entity, delta: float):
+	return
+	

--- a/godot/components/entities/behaviors/scripts/PatrolBehavior.gd
+++ b/godot/components/entities/behaviors/scripts/PatrolBehavior.gd
@@ -1,0 +1,29 @@
+extends EntityBehavior
+class_name PatrolBehavior
+
+
+@export var speed = 100.0
+@export var edge_detecting_x_distance = 8
+
+func apply_behavior(entity: Entity, delta: float):
+	# Add the gravity.
+	if not entity.is_on_floor():
+		entity.velocity.y += entity.gravity * delta
+		entity.velocity.y = minf(entity.velocity.y, entity.MAX_FALL_SPEED)
+		
+	if entity.is_on_wall() || _is_near_edge(entity):
+		scale.x = -1
+		entity._is_facing_right = !entity._is_facing_right
+		
+	entity.velocity.x = (1 if entity._is_facing_right else -1) * speed
+	
+func _is_near_edge(entity: Entity):
+	if edge_detecting_x_distance <= 0 || !entity.is_on_floor():
+		return false
+		
+	var space_state = get_world_2d().direct_space_state
+	var x_position = entity.global_position.x + (edge_detecting_x_distance if entity._is_facing_right else -edge_detecting_x_distance)
+	var edge_raycast = PhysicsRayQueryParameters2D.create(Vector2(x_position, entity.global_position.y - 2), Vector2(x_position, entity.global_position.y + 2))
+	var edge_result = space_state.intersect_ray(edge_raycast)
+	
+	return not edge_result

--- a/godot/components/game/game.tscn
+++ b/godot/components/game/game.tscn
@@ -27,8 +27,11 @@ tile_set = SubResource("TileSet_46f3p")
 [node name="Player" parent="." instance=ExtResource("1_jxhnh")]
 position = Vector2(11, -9)
 
+[node name="Camera2D2" type="Camera2D" parent="Player"]
+offset = Vector2(0, -48)
+
 [node name="Skeleton" parent="." instance=ExtResource("1_25xm7")]
-position = Vector2(422, -37)
+position = Vector2(239, -2)
 
 [node name="Ghost" parent="." instance=ExtResource("3_tsgwt")]
 position = Vector2(350, -34)

--- a/godot/components/player/player.gd
+++ b/godot/components/player/player.gd
@@ -1,4 +1,5 @@
 extends CharacterBody2D
+class_name Player
 
 @onready var animSprite = $AnimatedSprite2D;
 

--- a/godot/components/player/player.tscn
+++ b/godot/components/player/player.tscn
@@ -173,21 +173,19 @@ animations = [{
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_uca6y"]
 radius = 7.0
-height = 34.0
+height = 32.0
 
-[node name="Player" type="Node2D"]
-position = Vector2(1, 0)
-
-[node name="player" type="CharacterBody2D" parent="."]
+[node name="player" type="CharacterBody2D"]
+collision_layer = 2
 script = ExtResource("1_0ke4j")
 
-[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="player"]
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 z_index = 99
 texture_filter = 1
 sprite_frames = SubResource("SpriteFrames_u0yn2")
 animation = &"walk_up"
+offset = Vector2(0, -16)
 
-[node name="Hitbox" type="CollisionShape2D" parent="player"]
+[node name="Hitbox" type="CollisionShape2D" parent="."]
+position = Vector2(0, -16)
 shape = SubResource("CapsuleShape2D_uca6y")
-
-[node name="Camera2D" type="Camera2D" parent="player"]

--- a/godot/components/skeleton/skeleton.tscn
+++ b/godot/components/skeleton/skeleton.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=5 format=3 uid="uid://d1cbw1acmg7nt"]
+[gd_scene load_steps=7 format=3 uid="uid://d1cbw1acmg7nt"]
 
 [ext_resource type="Texture2D" uid="uid://dgjyb6i7kr4ui" path="res://components/skeleton/skeleton.png" id="1_di0av"]
+[ext_resource type="Script" path="res://components/entities/Entity.gd" id="1_ylskn"]
+[ext_resource type="Script" path="res://components/entities/behaviors/scripts/PatrolBehavior.gd" id="3_je6g3"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_khr7p"]
 atlas = ExtResource("1_di0av")
@@ -19,16 +21,22 @@ animations = [{
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_nmafq"]
 radius = 8.0
-height = 34.0
+height = 32.0
 
-[node name="Skeleton" type="Node2D"]
+[node name="CharacterBody2D" type="CharacterBody2D" node_paths=PackedStringArray("idle_behavior")]
+collision_layer = 4
+script = ExtResource("1_ylskn")
+idle_behavior = NodePath("PatrolBehavior")
 
-[node name="CharacterBody2D" type="CharacterBody2D" parent="."]
-
-[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="CharacterBody2D"]
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 texture_filter = 1
 sprite_frames = SubResource("SpriteFrames_oqrth")
 animation = &"idle"
+offset = Vector2(0, -16)
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="CharacterBody2D"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, -16)
 shape = SubResource("CapsuleShape2D_nmafq")
+
+[node name="PatrolBehavior" type="Node2D" parent="."]
+script = ExtResource("3_je6g3")

--- a/godot/components/utils/Hitbox2D.gd
+++ b/godot/components/utils/Hitbox2D.gd
@@ -1,0 +1,5 @@
+class_name Hitbox2D
+extends Area2D
+
+@export var tag = ""
+@export var damage = 10

--- a/godot/components/utils/Hurtbox2D.gd
+++ b/godot/components/utils/Hurtbox2D.gd
@@ -1,0 +1,21 @@
+class_name Hurtbox2D
+extends Area2D
+
+
+@export var can_take_damage = true
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	if can_take_damage:
+		connect("area_entered", self._on_hitbox_entered)
+
+
+func _on_hitbox_entered(hitbox):
+	if hitbox == null || !hitbox is Hitbox2D:
+		return
+	
+	if owner.has_method("take_damage"):
+		owner.take_damage(hitbox)
+	else:
+		print("owner does not have take_damage")

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -29,20 +29,30 @@ import/blender/enabled=false
 up={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 down={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 left={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 right={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+
+[layer_names]
+
+2d_physics/layer_1="GROUND"
+2d_physics/layer_2="PLAYER"
+2d_physics/layer_3="ENEMY"


### PR DESCRIPTION
Added:
- .gitignore
- Entity script
- Base Behavior and Patrol Behavior and applied it to the Skeleton as an example
- Hitbox and Hurtbox
-
Updated:
- Collision Layer names to be more intuitive (GROUND, PLAYER, ENEMY)
- Offsets on Player and Skeleton scenes to match industry standard
- Node tree on Player and Skeleton scenes to remove the empty root node
- Collision on Player and Skeleton so they only belong in their appropriate layer and mask the GROUND layer (physics hitboxes only care about GROUND, damage hurtboxes will collide with entities once damage is set up)
- Camera to exist in-level instead of on the player (sets up for smooth camera movement in the future, and decouples camera controls from the Player)
- Camera Y offset to show more space abov the player (you probably dont' want 50% of the screen to be taken up by ground)