### PR TITLE
Fix interactable bug

### DIFF
--- a/godot/scenes/appliances/fryer.tscn
+++ b/godot/scenes/appliances/fryer.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://be0vklh2rafgm" path="res://art/appliances/fryer-glow.png" id="3_010pc"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_2lnnv"]
+size = Vector2(14, 20)
 
 [node name="Fryer" type="Node2D"]
 

--- a/godot/scenes/appliances/griller.tscn
+++ b/godot/scenes/appliances/griller.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://cm5kp75peb2cj" path="res://art/appliances/griller-glow.png" id="3_htyu6"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_tpp4k"]
+size = Vector2(14, 20)
 
 [node name="Griller" type="Node2D"]
 

--- a/godot/scenes/appliances/stockpot.tscn
+++ b/godot/scenes/appliances/stockpot.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://dwe85d2wc3buf" path="res://art/appliances/stockpot-glow.png" id="3_v7u0p"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_orfx1"]
+size = Vector2(12, 20)
 
 [node name="Stockpot" type="Node2D"]
 

--- a/godot/scenes/entities/player.tscn
+++ b/godot/scenes/entities/player.tscn
@@ -317,7 +317,7 @@ radius = 7.0
 height = 32.0
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_fw7ub"]
-size = Vector2(20, 32)
+size = Vector2(12, 32)
 
 [node name="player" type="CharacterBody2D"]
 collision_layer = 2

--- a/godot/scenes/levels/campsite.tscn
+++ b/godot/scenes/levels/campsite.tscn
@@ -21,7 +21,7 @@ texture = ExtResource("1_4wb8j")
 physics_layer_0/collision_layer = 1
 sources/0 = SubResource("TileSetAtlasSource_60vbj")
 
-[node name="Game" type="Node2D"]
+[node name="Game2" type="Node2D"]
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
@@ -42,10 +42,10 @@ offset = Vector2(0, -48)
 process_callback = 0
 
 [node name="Stockpot" parent="." instance=ExtResource("5_bwvqj")]
-position = Vector2(112, 14)
+position = Vector2(108, 14)
 
 [node name="Griller" parent="." instance=ExtResource("6_6aqfy")]
-position = Vector2(90, 14)
+position = Vector2(80, 14)
 
 [node name="Fryer" parent="." instance=ExtResource("7_f2v7y")]
 position = Vector2(134, 14)

--- a/godot/scripts/entities/Player.gd
+++ b/godot/scripts/entities/Player.gd
@@ -71,7 +71,7 @@ func _physics_process(_delta):
 
 func _on_interaction_area_entered(interactable: Area2D):
 	print("interaction entered!")
-	if interactable.get_parent() is Interactable2D:
+	if _current_interactable == null && interactable.get_parent() is Interactable2D:
 		_current_interactable = interactable.get_parent()
 		_current_interactable.on_interact_enter(self)
 

--- a/godot/scripts/ui/InventoryDisplay.gd
+++ b/godot/scripts/ui/InventoryDisplay.gd
@@ -1,7 +1,7 @@
 extends Label
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	var bones = "b:" + str(Inventory.count(Enums.Item.BONES))
 	var zombie_flesh = "z:" + str(Inventory.count(Enums.Item.ZOMBIE_FLESH))
 	var ecto = "e:" + str(Inventory.count(Enums.Item.ECTO_SEASONING))


### PR DESCRIPTION
This ensures that the player will not change the `current_interactable` if one is already set. Therefore the player can't activate a new interactable until the old one is exited. 

Also shrinks down the interact areas in Appliances to reduce the chance of overlaps