### PR TITLE
Fix order spawns for day 4 and up

### DIFF
--- a/godot/scenes/entities/player.tscn
+++ b/godot/scenes/entities/player.tscn
@@ -7,7 +7,7 @@
 [ext_resource type="Script" path="res://scripts/components/Hurtbox2D.gd" id="4_tewki"]
 [ext_resource type="PackedScene" uid="uid://uwf634yd7txp" path="res://scenes/entities/projectiles/cleaver_projectile.tscn" id="5_e6val"]
 [ext_resource type="PackedScene" uid="uid://cxab4g5uyjvwb" path="res://scenes/entities/projectiles/fireball.tscn" id="6_dwdv3"]
-[ext_resource type="PackedScene" uid="uid://0kj3rafmxqta" path="res://scenes/entities/projectiles/mallet_projectile.tscn" id="8_lsrfr"]
+[ext_resource type="PackedScene" path="res://scenes/entities/projectiles/mallet_projectile.tscn" id="8_lsrfr"]
 [ext_resource type="Texture2D" uid="uid://dat0m52xxlryl" path="res://art/cooking/bone-chips.png" id="9_7s6ig"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_qvcwe"]

--- a/godot/scenes/levels/campsite.tscn
+++ b/godot/scenes/levels/campsite.tscn
@@ -13,7 +13,7 @@
 [ext_resource type="PackedScene" uid="uid://d27y573aox5wo" path="res://scenes/ui/recipe_menu.tscn" id="10_kxk1k"]
 [ext_resource type="PackedScene" uid="uid://cdyf3om11ummy" path="res://scenes/tools/flamethrower_tool.tscn" id="11_fo00j"]
 [ext_resource type="PackedScene" uid="uid://bnohdpspx1h3r" path="res://scenes/tools/mallet_tool.tscn" id="12_nwcby"]
-[ext_resource type="PackedScene" uid="uid://ipeq1yuy8ssp" path="res://scenes/tools/tool_rack.tscn" id="14_7er4o"]
+[ext_resource type="PackedScene" uid="uid://d1ya4ohs77sy3" path="res://scenes/tools/tool_rack.tscn" id="14_7er4o"]
 [ext_resource type="PackedScene" uid="uid://b6eqe082ieh3j" path="res://scenes/customers/bone_chips_customer.tscn" id="14_kxeof"]
 [ext_resource type="Script" path="res://scripts/utils/Customers.gd" id="14_qfe0o"]
 [ext_resource type="PackedScene" uid="uid://dbth4mwyr2lix" path="res://scenes/customers/zombie_steak_customer.tscn" id="15_rhndt"]

--- a/godot/scripts/components/Health.gd
+++ b/godot/scripts/components/Health.gd
@@ -14,6 +14,9 @@ func _ready():
 func get_health():
 	return _health;
 
+func set_health(health: int):
+	_health = health
+
 func add_health(amount: int = 1):
 	_health = min(max_health, _health + amount)
 	health_updated.emit(_health)

--- a/godot/scripts/entities/Player.gd
+++ b/godot/scripts/entities/Player.gd
@@ -87,6 +87,7 @@ func _ready():
 	_interactor.connect("area_exited", self._on_interaction_area_exited)
 	_animated_sprite.animation_finished.connect(self._on_animation_finished)
 	
+	health.set_health(GlobalState.carried_health)
 	health.connect("health_updated", self._on_health_updated)
 	print(health.health_zero)
 	health.health_zero.connect(self._death)

--- a/godot/scripts/utils/Customers.gd
+++ b/godot/scripts/utils/Customers.gd
@@ -44,6 +44,9 @@ func _get_insane_spawns() -> Array:
 
 func _get_spawn_positions() -> Array:
 	var positions: Array = []
+	var day_number = GlobalState.get_day()
+	if day_number > 3:
+		day_number = 3
 	var spawn_data = _spawns_for_day[GlobalState.get_day()]
 	for difficulty in spawn_data:
 		var spawns: Array

--- a/godot/scripts/utils/GlobalState.gd
+++ b/godot/scripts/utils/GlobalState.gd
@@ -68,6 +68,7 @@ func _serve_physics_process(delta):
 	pass
 
 func on_option_selected(id):
+	SoundManager.stop(Enums.SoundEffect.FLAMETHROWER)
 	SignalBus.selected_option.disconnect(on_option_selected)
 	match _game_state:
 		GameState.GATHER:


### PR DESCRIPTION
- Reenable carryover without breaking enemy health
- Stop flamethrower from playing infinitely on change scene